### PR TITLE
将minimatch的option改为可配置

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,10 @@ function AkWebpackPlugin(opts) {
 	this.config.beforeZip = opts.beforeZip || emptyFunc;
 	this.config.afterZip = opts.afterZip || emptyFunc;
 	this.fs = fs;
+	this.config.minimatchOpt = Object.assign({
+		matchBase: true,
+		dot: true
+	}, opts.minimatchOpt || {});
 }
 
 AkWebpackPlugin.prototype.apply = function(compiler) {
@@ -192,10 +196,7 @@ AkWebpackPlugin.prototype.excludeFiles = function() {
 		walkFiles.forEach((file) => {
 			// loop through exclude files patterns
 			item.exclude.forEach((match) => {
-				if (minimatch(file.path, match, {
-					matchBase: true,
-					dot: true
-				})) {
+				if (minimatch(file.path, match, this.config.minimatchOpt)) {
 					if (fs.existsSync(file.path)) {
 						fs.removeSync(file.path);
 					}


### PR DESCRIPTION
某些特殊场景，默认的minimatch 选项可能不够用，这里将配置项从使用侧透传，更灵活